### PR TITLE
Screed Record Slicing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,6 @@
-2015-06-02  Michael Wright  <wrigh517@msu.edu>
+2015-06-05  Michael Wright  <wrigh517@msu.edu>
 
-   * screedRecord.py: Allow slicing of screed records to fix issue 768
-   https://github.com/ged-lab/khmer/issues/768
+   * screedRecord.py: Allow slicing of screed records to fix issue #768
 
 2015-06-05  en zyme  <en_zyme@outlook.com>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-06-02  Michael Wright  <wrigh517@msu.edu>
+
+   * screedRecord.py: Allow slicing of screed records to fix issue 768
+   https://github.com/ged-lab/khmer/issues/768
+
 2015-06-05  en zyme  <en_zyme@outlook.com>
 
    * screed/tests/fastq.py: check for empty line in two places

--- a/screed/screedRecord.py
+++ b/screed/screedRecord.py
@@ -37,6 +37,16 @@ class Record(MutableMapping):
     def keys(self):
         return self.d.keys()
 
+    def __getitem__(self, idx):
+        if isinstance(idx, slice):
+            new_read = _screed_record_dict(self)
+            new_read['sequence'] = new_read.sequence[idx]
+            if hasattr(new_read, 'quality'):
+                new_read['quality'] = new_read.quality[idx]
+            return new_read
+        else:
+            return self.d[idx]
+
     def __delitem__(self, key):
         del self.d[key]
 

--- a/screed/screedRecord.py
+++ b/screed/screedRecord.py
@@ -39,7 +39,7 @@ class Record(MutableMapping):
 
     def __getitem__(self, idx):
         if isinstance(idx, slice):
-            new_read = _screed_record_dict(self)
+            new_read = Record(self)
             new_read['sequence'] = new_read.sequence[idx]
             if hasattr(new_read, 'quality'):
                 new_read['quality'] = new_read.quality[idx]

--- a/screed/screedRecord.py
+++ b/screed/screedRecord.py
@@ -19,9 +19,6 @@ class Record(MutableMapping):
     def __init__(self, *args, **kwargs):
         self.d = dict(*args, **kwargs)
 
-    def __getitem__(self, name):
-        return self.d[name]
-
     def __setitem__(self, name, value):
         self.d[name] = value
 
@@ -39,11 +36,14 @@ class Record(MutableMapping):
 
     def __getitem__(self, idx):
         if isinstance(idx, slice):
-            new_read = Record(self)
-            new_read['sequence'] = new_read.sequence[idx]
-            if hasattr(new_read, 'quality'):
-                new_read['quality'] = new_read.quality[idx]
-            return new_read
+            new_read = {k: self.d[k] for k in self.d
+                        if k not in ('sequence', 'quality')}
+
+            new_read['sequence'] = self.d['sequence'][idx]
+            if 'quality' in self.d:
+                new_read['quality'] = self.d['quality'][idx]
+
+            return Record(new_read)
         else:
             return self.d[idx]
 

--- a/screed/tests/test_fasta.py
+++ b/screed/tests/test_fasta.py
@@ -163,18 +163,6 @@ def test_fasta_slicing():
 
     for k in set(record.keys()) - {'sequence'}:
         assert trimmed[k] == record[k]
+
     assert trimmed['sequence'] == record['sequence'][:10]
-
-
-def test_fastq_slicing():
-    testfq = utils.get_temp_filename('test.fastq')
-    shutil.copy(utils.get_test_data('test.fastq'), testfq)
-
-    with screed.open(testfq) as index:
-        record = next(index)
-        trimmed = record[:10]
-
-    for k in set(record.keys()) - {'sequence', 'quality'}:
-        assert trimmed[k] == record[k]
-    assert trimmed['sequence'] == record['sequence'][:10]
-    assert trimmed['quality'] == record['quality'][:10]
+    assert trimmed.sequence == record.sequence[:10]

--- a/screed/tests/test_fasta.py
+++ b/screed/tests/test_fasta.py
@@ -44,7 +44,7 @@ class Test_fasta(object):
             intRcrd = self.db.loadRecordByIndex(record.id)
             assert record == intRcrd
 
-    def test_length(self):
+    def test_length_2(self):
         read = self.db[self.db.keys()[0]]
 
         assert len(read) == len(read.sequence)

--- a/screed/tests/test_fasta.py
+++ b/screed/tests/test_fasta.py
@@ -151,3 +151,28 @@ def test_writer_2():
     w.consume(read_iter)
 
     assert fp.getvalue() == '>foo bar\nATCG\n'
+
+
+class Test_fasta_slicing(object):
+
+    def setup(self):
+        self._testfa = os.path.join(os.path.dirname(__file__),
+                                    'test.fa')
+        self._index = screed.open(self._testfa)
+        self._record = self._index.next()
+
+    def test_slicing(self):
+        test_slice = self._record[:10]['name']
+        assert test_slice == "ENSMICT00000012722"
+
+
+class Test_fastq_slicing(object):
+    def setup(self):
+        self._testfq = os.path.join(os.path.dirname(__file__),
+                                    'test.fastq')
+        self._index = screed.open(self._testfq)
+
+    def test_slicing(self):
+        self._record = self._index.next()
+        test_slice = self._record['quality'][:10]
+        assert test_slice == "AA7AAA3+AA"

--- a/screed/tests/test_fasta.py
+++ b/screed/tests/test_fasta.py
@@ -153,26 +153,28 @@ def test_writer_2():
     assert fp.getvalue() == '>foo bar\nATCG\n'
 
 
-class Test_fasta_slicing(object):
+def test_fasta_slicing():
+    testfa = utils.get_temp_filename('test.fa')
+    shutil.copy(utils.get_test_data('test.fa'), testfa)
 
-    def setup(self):
-        self._testfa = os.path.join(os.path.dirname(__file__),
-                                    'test.fa')
-        self._index = screed.open(self._testfa)
-        self._record = self._index.next()
+    with screed.open(testfa) as index:
+        record = next(index)
+        trimmed = record[:10]
 
-    def test_slicing(self):
-        test_slice = self._record[:10]['name']
-        assert test_slice == "ENSMICT00000012722"
+    for k in set(record.keys()) - {'sequence'}:
+        assert trimmed[k] == record[k]
+    assert trimmed['sequence'] == record['sequence'][:10]
 
 
-class Test_fastq_slicing(object):
-    def setup(self):
-        self._testfq = os.path.join(os.path.dirname(__file__),
-                                    'test.fastq')
-        self._index = screed.open(self._testfq)
+def test_fastq_slicing():
+    testfq = utils.get_temp_filename('test.fastq')
+    shutil.copy(utils.get_test_data('test.fastq'), testfq)
 
-    def test_slicing(self):
-        self._record = self._index.next()
-        test_slice = self._record['quality'][:10]
-        assert test_slice == "AA7AAA3+AA"
+    with screed.open(testfq) as index:
+        record = next(index)
+        trimmed = record[:10]
+
+    for k in set(record.keys()) - {'sequence', 'quality'}:
+        assert trimmed[k] == record[k]
+    assert trimmed['sequence'] == record['sequence'][:10]
+    assert trimmed['quality'] == record['quality'][:10]

--- a/screed/tests/test_fastq.py
+++ b/screed/tests/test_fastq.py
@@ -154,3 +154,21 @@ def test_writer_2():
     w.consume(read_iter)
 
     assert fp.getvalue() == '@foo bar\nATCG\n+\n####\n'
+
+
+def test_fastq_slicing():
+    testfq = utils.get_temp_filename('test.fastq')
+    shutil.copy(utils.get_test_data('test.fastq'), testfq)
+
+    with screed.open(testfq) as index:
+        record = next(index)
+        trimmed = record[:10]
+
+    for k in set(record.keys()) - {'sequence', 'quality'}:
+        assert trimmed[k] == record[k]
+
+    assert trimmed['sequence'] == record['sequence'][:10]
+    assert trimmed.sequence == record.sequence[:10]
+
+    assert trimmed['quality'] == record['quality'][:10]
+    assert trimmed.quality == record.quality[:10]


### PR DESCRIPTION
For https://github.com/ged-lab/khmer/issues/768

opening this pull request automatically redirected me to:
https://github.com/ctb/screed/compare/master...ged-lab:record_slicing?expand=1 (CTB's branch, not /ged-lab/screed)
Is there a reason for that? I switched to ged-lab

@ctb, I accidentally committed this change to master instead of opening this new branch, can you possibly delete that commit?
