### PR TITLE
Python 3/2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python: 2.7
+
+env:
+  - TOX_ENV=py27
+  - TOX_ENV=py33
+  - TOX_ENV=py34
+
+install:
+  - pip install tox
+
+script: tox -e $TOX_ENV

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,7 @@ all:
 	./setup.py build
 
 install-dependencies:
-	pip2 install --user --upgrade $(DEVPKGS) || pip2 install --upgrade \
-		$(DEVPKGS) || pip install --user --upgrade $(DEVPKGS) || pip \
-		install --upgrade $(DEVPKGS)
+	pip install --upgrade $(DEVPKGS) || pip2 install --upgrade $(DEVPKGS)
 
 install: FORCE
 	./setup.py build install

--- a/bigtests/__init__.py
+++ b/bigtests/__init__.py
@@ -32,8 +32,8 @@ def getfile(f):
     try:
         up = urllib.urlopen(base_url)
     except IOError:
-        raise IOError, "Error downloading testfiles, are you connected to " +\
-              "the internet?"
+        raise IOError("Error downloading testfiles, are you connected to " +\
+              "the internet?")
     fp.write(up.read())
     fp.close()
 

--- a/screed/__init__.py
+++ b/screed/__init__.py
@@ -21,16 +21,18 @@ file into a screed database.
 Conversion between sequence file types is provided in the ToFastq and
 ToFasta functions
 """
-from openscreed import ScreedDB, open_writer
-from openscreed import open_reader as open
-from conversion import ToFastq
-from conversion import ToFasta
-from createscreed import create_db
-from seqparse import read_fastq_sequences
-from seqparse import read_fasta_sequences
-from dna import rc
-from screedRecord import Record
+from __future__ import absolute_import
 
-from _version import get_versions
+from .openscreed import ScreedDB, open_writer
+from .openscreed import open_reader as open
+from .conversion import ToFastq
+from .conversion import ToFasta
+from .createscreed import create_db
+from .seqparse import read_fastq_sequences
+from .seqparse import read_fasta_sequences
+from .dna import rc
+from .screedRecord import Record
+
+from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/screed/__init__.py
+++ b/screed/__init__.py
@@ -21,18 +21,19 @@ file into a screed database.
 Conversion between sequence file types is provided in the ToFastq and
 ToFasta functions
 """
+
 from __future__ import absolute_import
 
-from .openscreed import ScreedDB, open_writer
-from .openscreed import open_reader as open
-from .conversion import ToFastq
-from .conversion import ToFasta
-from .createscreed import create_db
-from .seqparse import read_fastq_sequences
-from .seqparse import read_fasta_sequences
-from .dna import rc
-from .screedRecord import Record
+from screed.openscreed import ScreedDB, open_writer
+from screed.openscreed import open_reader as open
+from screed.conversion import ToFastq
+from screed.conversion import ToFasta
+from screed.createscreed import create_db
+from screed.seqparse import read_fastq_sequences
+from screed.seqparse import read_fasta_sequences
+from screed.dna import rc
+from screed.screedRecord import Record
 
-from ._version import get_versions
+from screed._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/screed/_version.py
+++ b/screed/_version.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag

--- a/screed/_version.py
+++ b/screed/_version.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag

--- a/screed/conversion.py
+++ b/screed/conversion.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 # Copyright (c) 2008-2010, Michigan State University
 
-from openscreed import ScreedDB
+from .openscreed import ScreedDB
 
 _MAXLINELEN = 80
 _null_quality = '\"'  # ASCII 34, e.g 75% chance of incorrect read

--- a/screed/conversion.py
+++ b/screed/conversion.py
@@ -55,11 +55,11 @@ def ToFastq(dbFile, outputFile):
     db = ScreedDB(dbFile)
 
     for value in db.itervalues():
-        outFile.write('@%s %s\n%s\n+\n%s\n' % (value['name'],
-                                               GetComments(value),
-                                               linewrap(
-                                                   str(value['sequence'])),
-                                               GenerateQuality(value)))
+        line = '@%s %s\n%s\n+\n%s\n' % (value['name'],
+                                        GetComments(value),
+                                        linewrap(str(value['sequence'])),
+                                        GenerateQuality(value))
+        outFile.write(line.encode('UTF-8'))
     db.close()
     outFile.close()
 
@@ -73,8 +73,9 @@ def ToFasta(dbFile, outputFile):
     db = ScreedDB(dbFile)
 
     for value in db.itervalues():
-        outFile.write('>%s %s\n%s\n' % (value['name'], GetComments(value),
-                                        linewrap(str(value['sequence']))))
+        line = '>%s %s\n%s\n' % (value['name'], GetComments(value),
+                                 linewrap(str(value['sequence'])))
+        outFile.write(line.encode('UTF-8'))
 
     db.close()
     outFile.close()

--- a/screed/createscreed.py
+++ b/screed/createscreed.py
@@ -1,4 +1,5 @@
-import DBConstants
+from __future__ import absolute_import
+from . import DBConstants
 import os
 import sqlite3
 import itertools

--- a/screed/dna.py
+++ b/screed/dna.py
@@ -1,5 +1,5 @@
-import string
 import array
+import string
 
 legal_dna = "ACGTN"
 
@@ -21,7 +21,7 @@ def reverse_complement(s):
     """
     Build reverse complement of 's'.
     """
-    s = string.upper(s)
+    s = s.upper()
     assert is_DNA(s), "Your sequence must be DNA!"
 
     r = reverse(s)
@@ -29,16 +29,21 @@ def reverse_complement(s):
 
     return rc
 
+
 rc = reverse_complement                 # alias 'rc' to 'reverse_complement'
 
-__complementTranslation = string.maketrans('ACTG', 'TGAC')
+try:
+    __complementTranslation = str.maketrans('ACTG', 'TGAC')
+except AttributeError:
+    __complementTranslation = string.maketrans('ACTG', 'TGAC')
+
 
 
 def complement(s):
     """
     Return complement of 's'.
     """
-    c = string.translate(s, __complementTranslation)
+    c = s.translate(__complementTranslation)
     return c
 
 
@@ -46,8 +51,6 @@ def reverse(s):
     """
     Return reverse of 's'.
     """
-    r = array.array('c', s)
-    r.reverse()
-    r = string.join(r, '')
+    r = "".join(reversed(s))
 
     return r

--- a/screed/dna.py
+++ b/screed/dna.py
@@ -38,7 +38,6 @@ except AttributeError:
     __complementTranslation = string.maketrans('ACTG', 'TGAC')
 
 
-
 def complement(s):
     """
     Return complement of 's'.

--- a/screed/dump_to_fasta.py
+++ b/screed/dump_to_fasta.py
@@ -2,6 +2,7 @@
 
 # Copyright (c) 2008-2010, Michigan State University
 
+from __future__ import print_function
 from screed import ToFasta
 import sys
 import os
@@ -9,14 +10,14 @@ import os
 # Shell interface to the ToFasta screed conversion function
 if __name__ == '__main__':
     if len(sys.argv) != 3:
-        print "Usage: %s <dbfilename> <outputfilename>" % sys.argv[0]
+        print("Usage: %s <dbfilename> <outputfilename>" % sys.argv[0])
         exit(1)
 
     dbFile = sys.argv[1]
     outputFile = sys.argv[2]
 
     if not os.path.isfile(dbFile):
-        print "No such file: %s" % dbFile
+        print("No such file: %s" % dbFile)
         exit(1)
     if os.path.isfile(outputFile):
         os.unlink(outputFile)

--- a/screed/dump_to_fastq.py
+++ b/screed/dump_to_fastq.py
@@ -2,6 +2,7 @@
 
 # Copyright (c) 2008-2010, Michigan State University
 
+from __future__ import print_function
 from screed import ToFastq
 import sys
 import os
@@ -9,14 +10,14 @@ import os
 # Shell interface to the ToFastq screed conversion function
 if __name__ == '__main__':
     if len(sys.argv) != 3:
-        print "Usage: %s <dbfilename> <outputfilename>" % sys.argv[0]
+        print("Usage: %s <dbfilename> <outputfilename>" % sys.argv[0])
         exit(1)
 
     dbFile = sys.argv[1]
     outputFile = sys.argv[2]
 
     if not os.path.isfile(dbFile):
-        print "No such file: %s" % dbFile
+        print("No such file: %s" % dbFile)
         exit(1)
     if os.path.isfile(outputFile):
         os.unlink(outputFile)

--- a/screed/fadbm.py
+++ b/screed/fadbm.py
@@ -2,9 +2,11 @@
 
 # Copyright (c) 2008-2010, Michigan State University
 
+from __future__ import print_function
+from __future__ import absolute_import
 import sys
-from __init__ import read_fasta_sequences
-import DBConstants
+from .__init__ import read_fasta_sequences
+from . import DBConstants
 
 # A shell interface to the screed FADBM database writing function
 if __name__ == "__main__":
@@ -16,4 +18,4 @@ if __name__ == "__main__":
     filename = sys.argv[1]
     read_fasta_sequences(filename)
 
-    print "Database saved in %s%s" % (sys.argv[1], DBConstants.fileExtension)
+    print("Database saved in %s%s" % (sys.argv[1], DBConstants.fileExtension))

--- a/screed/fadbm.py
+++ b/screed/fadbm.py
@@ -2,11 +2,9 @@
 
 # Copyright (c) 2008-2010, Michigan State University
 
-from __future__ import print_function
-from __future__ import absolute_import
 import sys
-from .__init__ import read_fasta_sequences
-from . import DBConstants
+from __init__ import read_fasta_sequences
+import DBConstants
 
 # A shell interface to the screed FADBM database writing function
 if __name__ == "__main__":

--- a/screed/fasta.py
+++ b/screed/fasta.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
+
 from . import DBConstants
 from .screedRecord import Record, _Writer
+from .utils import to_str
 
 FieldTypes = (('name', DBConstants._INDEXED_TEXT_KEY),
               ('description', DBConstants._STANDARD_TEXT),
@@ -18,7 +20,7 @@ def fasta_iter(handle, parse_description=True, line=None):
     while line:
         data = Record()
 
-        line = line.strip()
+        line = to_str(line.strip())
         if not line.startswith('>'):
             raise IOError("Bad FASTA format: no '>' at beginning of line")
 
@@ -37,10 +39,10 @@ def fasta_iter(handle, parse_description=True, line=None):
 
         # Collect sequence lines into a list
         sequenceList = []
-        line = handle.readline()
+        line = to_str(handle.readline())
         while line and not line.startswith('>'):
             sequenceList.append(line.strip())
-            line = handle.readline()
+            line = to_str(handle.readline())
 
         data['sequence'] = ''.join(sequenceList)
         yield data

--- a/screed/fasta.py
+++ b/screed/fasta.py
@@ -1,5 +1,6 @@
-import DBConstants
-from screedRecord import Record, _Writer
+from __future__ import absolute_import
+from . import DBConstants
+from .screedRecord import Record, _Writer
 
 FieldTypes = (('name', DBConstants._INDEXED_TEXT_KEY),
               ('description', DBConstants._STANDARD_TEXT),

--- a/screed/fastq.py
+++ b/screed/fastq.py
@@ -1,5 +1,8 @@
-import DBConstants
-from screedRecord import Record, _Writer
+from __future__ import absolute_import
+
+from . import DBConstants
+from .screedRecord import Record, _Writer
+
 FieldTypes = (('name', DBConstants._INDEXED_TEXT_KEY),
               ('annotations', DBConstants._STANDARD_TEXT),
               ('sequence', DBConstants._STANDARD_TEXT),

--- a/screed/fastq.py
+++ b/screed/fastq.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from . import DBConstants
 from .screedRecord import Record, _Writer
+from .utils import to_str
 
 FieldTypes = (('name', DBConstants._INDEXED_TEXT_KEY),
               ('annotations', DBConstants._STANDARD_TEXT),
@@ -16,7 +17,7 @@ def fastq_iter(handle, line=None, parse_description=True):
     """
     if line is None:
         line = handle.readline()
-    line = line.strip()
+    line = to_str(line.strip())
     while line:
         data = Record()
 
@@ -37,22 +38,22 @@ def fastq_iter(handle, line=None, parse_description=True):
 
         # Extract the sequence lines
         sequence = []
-        line = handle.readline().strip()
+        line = to_str(handle.readline().strip())
         while not line.startswith('+') and not line.startswith('#'):
             sequence.append(line)
-            line = handle.readline().strip()
+            line = to_str(handle.readline().strip())
 
         data['sequence'] = ''.join(sequence)
 
         # Extract the quality lines
         quality = []
-        line = handle.readline().strip()
+        line = to_str(handle.readline().strip())
         seqlen = len(data['sequence'])
         aclen = 0
         while not line == '' and aclen < seqlen:
             quality.append(line)
             aclen += len(line)
-            line = handle.readline().strip()
+            line = to_str(handle.readline().strip())
 
         data['quality'] = ''.join(quality)
         if len(data['sequence']) != len(data['quality']):

--- a/screed/fqdbm.py
+++ b/screed/fqdbm.py
@@ -2,9 +2,11 @@
 
 # Copyright (c) 2008-2010, Michigan State University
 
+from __future__ import print_function
+from __future__ import absolute_import
 import sys
-from __init__ import read_fastq_sequences
-import DBConstants
+from .__init__ import read_fastq_sequences
+from . import DBConstants
 
 # A shell interface to the screed FQDBM database writing function
 if __name__ == "__main__":
@@ -16,5 +18,5 @@ if __name__ == "__main__":
     filename = sys.argv[1]
     read_fastq_sequences(filename)
 
-    print "Database saved in %s%s" % (sys.argv[1], DBConstants.fileExtension)
+    print("Database saved in %s%s" % (sys.argv[1], DBConstants.fileExtension))
     exit(0)

--- a/screed/fqdbm.py
+++ b/screed/fqdbm.py
@@ -2,11 +2,11 @@
 
 # Copyright (c) 2008-2010, Michigan State University
 
-from __future__ import print_function
 from __future__ import absolute_import
+
 import sys
-from .__init__ import read_fastq_sequences
-from . import DBConstants
+from screed import read_fastq_sequences
+from screed import DBConstants
 
 # A shell interface to the screed FQDBM database writing function
 if __name__ == "__main__":

--- a/screed/hava.py
+++ b/screed/hava.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from . import DBConstants
+from .utils import to_str
 
 FieldTypes = (('hava', DBConstants._INDEXED_TEXT_KEY),
               ('quarzk', DBConstants._STANDARD_TEXT),
@@ -15,14 +16,14 @@ def hava_iter(handle):
     is a handle to a file opened for reading
     """
     data = {}
-    line = handle.readline().strip()
+    line = to_str(handle.readline().strip())
     while line:
         data['hava'] = line
-        data['quarzk'] = handle.readline().strip()
-        data['muchalo'] = handle.readline().strip()
-        data['fakours'] = handle.readline().strip()
-        data['selimizicka'] = handle.readline().strip()
-        data['marshoon'] = handle.readline().strip()
+        data['quarzk'] = to_str(handle.readline().strip())
+        data['muchalo'] = to_str(handle.readline().strip())
+        data['fakours'] = to_str(handle.readline().strip())
+        data['selimizicka'] = to_str(handle.readline().strip())
+        data['marshoon'] = to_str(handle.readline().strip())
 
-        line = handle.readline().strip()
+        line = to_str(handle.readline().strip())
         yield data

--- a/screed/hava.py
+++ b/screed/hava.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 from . import DBConstants
 from .utils import to_str
 

--- a/screed/hava.py
+++ b/screed/hava.py
@@ -1,4 +1,5 @@
-import DBConstants
+from __future__ import absolute_import
+from . import DBConstants
 
 FieldTypes = (('hava', DBConstants._INDEXED_TEXT_KEY),
               ('quarzk', DBConstants._STANDARD_TEXT),

--- a/screed/openscreed.py
+++ b/screed/openscreed.py
@@ -275,7 +275,7 @@ class ScreedDB(MutableMapping):
         """
         Iterator over records in the database
         """
-        for index in xrange(1, self.__len__() + 1):
+        for index in range(1, self.__len__() + 1):
             yield screedRecord._buildRecord(self.fields, self._db,
                                             index,
                                             DBConstants._PRIMARY_KEY)

--- a/screed/openscreed.py
+++ b/screed/openscreed.py
@@ -297,6 +297,9 @@ class ScreedDB(MutableMapping):
         for v in self.itervalues():
             yield v[DBConstants._PRIMARY_KEY], v
 
+    def __iter__(self):
+        return self.iterkeys()
+
     def has_key(self, key):
         """
         Returns true if given key exists in database, false otherwise
@@ -323,6 +326,12 @@ class ScreedDB(MutableMapping):
     # Here follow the methods that are not implemented
 
     def __setitem__(self, something):
+        """
+        Not implemented (Read-only database)
+        """
+        raise AttributeError
+
+    def __delitem__(self, something):
         """
         Not implemented (Read-only database)
         """

--- a/screed/openscreed.py
+++ b/screed/openscreed.py
@@ -327,40 +327,40 @@ class ScreedDB(MutableMapping):
         """
         Not implemented (Read-only database)
         """
-        raise AttributeError
+        raise NotImplementedError
 
     def __delitem__(self, something):
         """
         Not implemented (Read-only database)
         """
-        raise AttributeError
+        raise NotImplementedError
 
     def clear(self):
         """
         Not implemented (Read-only database)
         """
-        raise AttributeError
+        raise NotImplementedError
 
     def update(self, something):
         """
         Not implemented (Read-only database)
         """
-        raise AttributeError
+        raise NotImplementedError
 
     def setdefault(self, something):
         """
         Not implemented (Read-only database)
         """
-        raise AttributeError
+        raise NotImplementedError
 
     def pop(self):
         """
         Not implemented (Read-only database)
         """
-        raise AttributeError
+        raise NotImplementedError
 
     def popitem(self):
         """
         Not implemented (Read-only database)
         """
-        raise AttributeError
+        raise NotImplementedError

--- a/screed/openscreed.py
+++ b/screed/openscreed.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2008-2015, Michigan State University
 """Reader and writer for screed."""
 
+from __future__ import absolute_import
+
 import os
 import types
 import UserDict
@@ -11,10 +13,10 @@ import StringIO
 import io
 import sys
 
-import DBConstants
-import screedRecord
-from fastq import fastq_iter, FASTQ_Writer
-from fasta import fasta_iter, FASTA_Writer
+from . import DBConstants
+from . import screedRecord
+from .fastq import fastq_iter, FASTQ_Writer
+from .fasta import fasta_iter, FASTA_Writer
 
 
 def get_writer_class(read_iter):

--- a/screed/openscreed.py
+++ b/screed/openscreed.py
@@ -59,8 +59,8 @@ class Open(object):
         Deals with .gz, FASTA, and FASTQ records.
         """
         magic_dict = {
-            "\x1f\x8b\x08": "gz",
-            "\x42\x5a\x68": "bz2",
+            b"\x1f\x8b\x08": "gz",
+            b"\x42\x5a\x68": "bz2",
             # "\x50\x4b\x03\x04": "zip"
         }  # Inspired by http://stackoverflow.com/a/13044946/1585509
         filename = _normalize_filename(filename)
@@ -88,12 +88,19 @@ class Open(object):
 
         iter_fn = None
         try:
-            if peek[0] == '>':
-                iter_fn = fasta_iter
-            elif peek[0] == '@':
-                iter_fn = fastq_iter
+            first_char = peek[0]
         except IndexError as err:
             return []  # empty file
+
+        try:
+            first_char = chr(first_char)
+        except TypeError:
+            pass
+
+        if first_char == '>':
+            iter_fn = fasta_iter
+        elif first_char == '@':
+            iter_fn = fastq_iter
 
         if iter_fn is None:
             raise ValueError("unknown file format for '%s'" % filename)
@@ -115,6 +122,7 @@ class Open(object):
     def close(self):
         if self.sequencefile is not None:
             self.sequencefile.close()
+
 
 _open = open
 open = Open

--- a/screed/openscreed.py
+++ b/screed/openscreed.py
@@ -5,13 +5,18 @@ from __future__ import absolute_import
 
 import os
 import types
-import UserDict
 import sqlite3
 import gzip
 import bz2file
-import StringIO
 import io
 import sys
+
+try:
+    from collections import MutableMapping
+except ImportError:
+    import UserDict
+    MutableMapping = UserDict.DictMixin
+
 
 from . import DBConstants
 from . import screedRecord
@@ -116,7 +121,7 @@ open = Open
 open_reader = open
 
 
-class ScreedDB(object, UserDict.DictMixin):
+class ScreedDB(MutableMapping):
 
     """
     Core on-disk dictionary interface for reading screed databases. Accepts a

--- a/screed/pygr_api.py
+++ b/screed/pygr_api.py
@@ -27,7 +27,6 @@ fadbm or fqdbm.
 
 CTB 3/20/09
 """
-from __future__ import print_function
 
 import UserDict
 

--- a/screed/pygr_api.py
+++ b/screed/pygr_api.py
@@ -155,7 +155,7 @@ class _ScreedSeqInfoDict_ByIndex(object, UserDict.DictMixin):
         return _ScreedSequenceInfo(k, v)
 
     def keys(self):
-        return xrange(0, len(self.sdb))
+        return range(0, len(self.sdb))
 
     def iterkeys(self):
         i = 0

--- a/screed/pygr_api.py
+++ b/screed/pygr_api.py
@@ -27,6 +27,7 @@ fadbm or fqdbm.
 
 CTB 3/20/09
 """
+from __future__ import print_function
 
 import UserDict
 
@@ -171,8 +172,8 @@ if __name__ == '__main__':
 
     db = ScreedSequenceDB(filename)
     for k in db:
-        print k, repr(db[k]), db[k].name
+        print(k, repr(db[k]), db[k].name)
 
     db = ScreedSequenceDB_ByIndex(filename)
     for k in db:
-        print k, repr(db[k]), db[k].name
+        print(k, repr(db[k]), db[k].name)

--- a/screed/screedRecord.py
+++ b/screed/screedRecord.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 import UserDict
 import types
-import DBConstants
+from . import DBConstants
 import gzip
 import bz2
 

--- a/screed/screedRecord.py
+++ b/screed/screedRecord.py
@@ -10,6 +10,7 @@ except ImportError:
     import UserDict
     MutableMapping = UserDict.DictMixin
 
+
 class Record(MutableMapping):
     """
     Simple dict-like record interface with bag behavior.

--- a/screed/screedRecord.py
+++ b/screed/screedRecord.py
@@ -42,9 +42,6 @@ class Record(MutableMapping):
     def __iter__(self):
         return iter(self.d)
 
-    def __len__(self):
-        return len(self.d)
-
 
 class _screed_attr(object):
 

--- a/screed/screedRecord.py
+++ b/screed/screedRecord.py
@@ -42,6 +42,9 @@ class Record(MutableMapping):
     def __iter__(self):
         return iter(self.d)
 
+    def __repr__(self):
+        return repr(self.d)
+
 
 class _screed_attr(object):
 

--- a/screed/screedRecord.py
+++ b/screed/screedRecord.py
@@ -1,13 +1,16 @@
 from __future__ import absolute_import
-import UserDict
 import types
 from . import DBConstants
 import gzip
 import bz2
 
+try:
+    from collections import MutableMapping
+except ImportError:
+    import UserDict
+    MutableMapping = UserDict.DictMixin
 
-class Record(UserDict.DictMixin):
-
+class Record(MutableMapping):
     """
     Simple dict-like record interface with bag behavior.
     """
@@ -32,6 +35,15 @@ class Record(UserDict.DictMixin):
 
     def keys(self):
         return self.d.keys()
+
+    def __delitem__(self, key):
+        del self.d[key]
+
+    def __iter__(self):
+        return iter(self.d)
+
+    def __len__(self):
+        return len(self.d)
 
 
 class _screed_attr(object):

--- a/screed/seqparse.py
+++ b/screed/seqparse.py
@@ -5,13 +5,14 @@ seqparse contains custom sequence parsers for extending screed's
 functionality to arbitrary sequence formats. An example 'hava'
 parser is included for API reference
 """
+from __future__ import absolute_import
 
 import os
-from createscreed import create_db
-from openscreed import ScreedDB
-import fastq
-import fasta
-import hava
+from .createscreed import create_db
+from .openscreed import ScreedDB
+from . import fastq
+from . import fasta
+from . import hava
 
 # [AN] these functions look strangely similar
 
@@ -20,7 +21,7 @@ def read_fastq_sequences(filename):
     """
     Function to parse text from the given FASTQ file into a screed database
     """
-    import openscreed
+    from . import openscreed
 
     # Will raise an exception if the file doesn't exist
     iterfunc = openscreed.open(filename)
@@ -35,7 +36,7 @@ def read_fasta_sequences(filename):
     """
     Function to parse text from the given FASTA file into a screed database
     """
-    import openscreed
+    from . import openscreed
 
     # Will raise an exception if the file doesn't exist
     iterfunc = openscreed.open(filename)

--- a/screed/seqparse.py
+++ b/screed/seqparse.py
@@ -5,11 +5,14 @@ seqparse contains custom sequence parsers for extending screed's
 functionality to arbitrary sequence formats. An example 'hava'
 parser is included for API reference
 """
+
 from __future__ import absolute_import
 
 import os
+
 from .createscreed import create_db
 from .openscreed import ScreedDB
+from . import openscreed
 from . import fastq
 from . import fasta
 from . import hava
@@ -21,8 +24,6 @@ def read_fastq_sequences(filename):
     """
     Function to parse text from the given FASTQ file into a screed database
     """
-    from . import openscreed
-
     # Will raise an exception if the file doesn't exist
     iterfunc = openscreed.open(filename)
 
@@ -36,8 +37,6 @@ def read_fasta_sequences(filename):
     """
     Function to parse text from the given FASTA file into a screed database
     """
-    from . import openscreed
-
     # Will raise an exception if the file doesn't exist
     iterfunc = openscreed.open(filename)
 

--- a/screed/tests/havaGen.py
+++ b/screed/tests/havaGen.py
@@ -17,6 +17,7 @@ the nosetests.
 This is a work of fiction. Names are the product of the author's imagination
 and any resemblance to real life is entirely coincidental.
 """
+from __future__ import print_function
 
 import sys
 import os
@@ -90,7 +91,7 @@ def createHavaFiles(filename, size, divisions):
 
 if __name__ == '__main__':
     if len(sys.argv) != 4:
-        print "Usage: <filename> <size> <divisions>"
+        print("Usage: <filename> <size> <divisions>")
         exit(1)
 
     filename = sys.argv[1]

--- a/screed/tests/screed_tst_utils.py
+++ b/screed/tests/screed_tst_utils.py
@@ -12,7 +12,7 @@ import tempfile
 import os
 import shutil
 from pkg_resources import Requirement, resource_filename, ResolutionError
-from cStringIO import StringIO
+from io import StringIO
 import nose
 import sys
 import traceback

--- a/screed/tests/test_convert.py
+++ b/screed/tests/test_convert.py
@@ -1,8 +1,9 @@
-import test_fasta
+from __future__ import absolute_import
+from . import test_fasta
 import os
 import screed
 from screed.DBConstants import fileExtension
-import screed_tst_utils as utils
+from . import screed_tst_utils as utils
 import shutil
 
 

--- a/screed/tests/test_dictionary.py
+++ b/screed/tests/test_dictionary.py
@@ -27,15 +27,15 @@ class Test_dict_methods(object):
         db = self.db
         keys = db.keys()
         ikeys = list(db.iterkeys())
-        assert sorted(keys) == sorted(ikeys)
+        assert all(key in ikeys for key in keys)
 
         values = db.values()
         ivalues = list(db.itervalues())
-        assert sorted(values) == sorted(ivalues)
+        assert all(value in ivalues for value in values)
 
         items = db.items()
         iitems = list(db.iteritems())
-        assert sorted(items) == sorted(iitems)
+        assert all(item in iitems for item in items)
 
     def test_contains(self):
         for k in self.db:

--- a/screed/tests/test_dictionary.py
+++ b/screed/tests/test_dictionary.py
@@ -1,7 +1,8 @@
+from __future__ import absolute_import
 import os
 import screed
 from screed.DBConstants import fileExtension
-import screed_tst_utils as utils
+from . import screed_tst_utils as utils
 import shutil
 
 

--- a/screed/tests/test_dictionary.py
+++ b/screed/tests/test_dictionary.py
@@ -74,29 +74,29 @@ class Test_dict_methods(object):
         try:
             db.clear()
             assert 0
-        except AttributeError:
+        except NotImplementedError:
             pass
 
         try:
             db.update({})
             assert 0
-        except AttributeError:
+        except NotImplementedError:
             pass
 
         try:
             db.setdefault(None)
             assert 0
-        except AttributeError:
+        except NotImplementedError:
             pass
 
         try:
             db.pop()
             assert 0
-        except AttributeError:
+        except NotImplementedError:
             pass
 
         try:
             db.popitem()
             assert 0
-        except AttributeError:
+        except NotImplementedError:
             pass

--- a/screed/tests/test_fasta.py
+++ b/screed/tests/test_fasta.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 import screed
 from screed.DBConstants import fileExtension
 import os

--- a/screed/tests/test_fasta.py
+++ b/screed/tests/test_fasta.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import screed
 from screed.DBConstants import fileExtension
 import os
-from cStringIO import StringIO
+from io import StringIO
 from . import screed_tst_utils as utils
 import shutil
 

--- a/screed/tests/test_fasta.py
+++ b/screed/tests/test_fasta.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 import screed
 from screed.DBConstants import fileExtension
 import os
 from cStringIO import StringIO
-import screed_tst_utils as utils
+from . import screed_tst_utils as utils
 import shutil
 
 

--- a/screed/tests/test_fasta.py
+++ b/screed/tests/test_fasta.py
@@ -93,7 +93,7 @@ class Test_fasta(object):
             entries.append(self.db[entry])
 
         ivalues = list(self.db.itervalues())
-        assert sorted(entries) == sorted(ivalues)
+        assert all(entry in ivalues for entry in entries)
 
     def test_iteri(self):
         for id, entry in self.db.iteritems():

--- a/screed/tests/test_fasta_recover.py
+++ b/screed/tests/test_fasta_recover.py
@@ -1,8 +1,9 @@
-import test_fasta
+from __future__ import absolute_import
+from . import test_fasta
 import os
 import screed
 from screed.DBConstants import fileExtension
-import screed_tst_utils as utils
+from . import screed_tst_utils as utils
 import shutil
 
 

--- a/screed/tests/test_fastq.py
+++ b/screed/tests/test_fastq.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 import screed
 from screed.DBConstants import fileExtension
 import os

--- a/screed/tests/test_fastq.py
+++ b/screed/tests/test_fastq.py
@@ -110,7 +110,7 @@ class Test_fastq(object):
             entries.append(self.db[entry])
 
         ivalues = list(self.db.itervalues())
-        assert sorted(entries) == sorted(ivalues)
+        assert all(entry in ivalues for entry in entries)
 
     def test_iteri(self):
         for id, entry in self.db.iteritems():

--- a/screed/tests/test_fastq.py
+++ b/screed/tests/test_fastq.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import screed
 from screed.DBConstants import fileExtension
 import os
-from cStringIO import StringIO
+from io import StringIO
 from . import screed_tst_utils as utils
 import shutil
 

--- a/screed/tests/test_fastq.py
+++ b/screed/tests/test_fastq.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 import screed
 from screed.DBConstants import fileExtension
 import os
 from cStringIO import StringIO
-import screed_tst_utils as utils
+from . import screed_tst_utils as utils
 import shutil
 
 

--- a/screed/tests/test_fastq_recover.py
+++ b/screed/tests/test_fastq_recover.py
@@ -1,8 +1,9 @@
-import test_fastq
+from __future__ import absolute_import
+from . import test_fastq
 import os
 import screed
 from screed.DBConstants import fileExtension
-import screed_tst_utils as utils
+from . import screed_tst_utils as utils
 import shutil
 
 

--- a/screed/tests/test_hava_methods.py
+++ b/screed/tests/test_hava_methods.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 import screed
 import screed.seqparse
 from screed.DBConstants import fileExtension
 import os
-import screed_tst_utils as utils
+from . import screed_tst_utils as utils
 import shutil
 
 testha = utils.get_temp_filename('test.hava')

--- a/screed/tests/test_open.py
+++ b/screed/tests/test_open.py
@@ -30,10 +30,11 @@ def test_open_stdin():
 
     Uses a subprocess with the data file directlyused as stdin."""
     filename1 = utils.get_test_data('test.fa')
-    command = ["python", "-c", "import screed; print list(screed.open('-'))"]
+    command = ["python", "-c", "from __future__ import print_function;"
+               "import screed; print(list(screed.open('-')))"]
     with open(filename1, 'rb') as data_file:
         output = subprocess.Popen(command,
-                                  stdin=data_file,
+                                  stdin=data_file, universal_newlines=True,
                                   stdout=subprocess.PIPE).communicate()[0]
         assert "'name': 'ENSMICT00000012722'" in output, output
 

--- a/screed/tests/test_open.py
+++ b/screed/tests/test_open.py
@@ -1,9 +1,12 @@
 # Copyright (c) 2008-2015, Michigan State University
 
+from __future__ import absolute_import
+
 import os.path
 import sys
 import subprocess
-import screed_tst_utils as utils
+
+from . import screed_tst_utils as utils
 import screed
 import screed.openscreed
 

--- a/screed/tests/test_open.py
+++ b/screed/tests/test_open.py
@@ -36,7 +36,8 @@ def test_open_stdin():
         output = subprocess.Popen(command,
                                   stdin=data_file, universal_newlines=True,
                                   stdout=subprocess.PIPE).communicate()[0]
-        assert "'name': 'ENSMICT00000012722'" in output, output
+        assert "'name': 'ENSMICT00000012722'" \
+            or "'name': u'ENSMICT00000012722'" in output, output
 
 
 def test_simple_open():

--- a/screed/tests/test_open.py
+++ b/screed/tests/test_open.py
@@ -35,7 +35,7 @@ def test_open_stdin():
         output = subprocess.Popen(command,
                                   stdin=data_file,
                                   stdout=subprocess.PIPE).communicate()[0]
-        assert "'name': 'ENSMICT00000012722'" in output
+        assert "'name': 'ENSMICT00000012722'" in output, output
 
 
 def test_simple_open():

--- a/screed/tests/test_open_cm.py
+++ b/screed/tests/test_open_cm.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2008-2015, Michigan State University
 
-import screed_tst_utils as utils
+from . import screed_tst_utils as utils
 import screed
 import screed.openscreed
 

--- a/screed/tests/test_pygr_api.py
+++ b/screed/tests/test_pygr_api.py
@@ -2,6 +2,8 @@
 Test the pygr API.
 """
 
+from __future__ import absolute_import, unicode_literals
+
 try:
     import pygr
 except ImportError:

--- a/screed/tests/test_pygr_api.py
+++ b/screed/tests/test_pygr_api.py
@@ -12,7 +12,7 @@ import screed
 from screed.DBConstants import fileExtension
 from screed.pygr_api import ScreedSequenceDB, ScreedSequenceDB_ByIndex
 from pickle import dump, load
-from cStringIO import StringIO
+from io import StringIO
 import os
 
 testfa = os.path.join(os.path.dirname(__file__), 'test.fa')

--- a/screed/tests/test_shell.py
+++ b/screed/tests/test_shell.py
@@ -1,10 +1,11 @@
-import test_fasta
-import test_fastq
+from __future__ import absolute_import
+from . import test_fasta
+from . import test_fastq
 import os
 import subprocess
 import screed
 from screed.DBConstants import fileExtension
-import screed_tst_utils as utils
+from . import screed_tst_utils as utils
 import shutil
 
 

--- a/screed/tests/test_streaming.py
+++ b/screed/tests/test_streaming.py
@@ -1,16 +1,21 @@
 # Copyright (c) 2008-2015, Michigan State University
 
-import test_fasta
-import test_fastq
+from __future__ import print_function
+from __future__ import absolute_import
+
 import tempfile
 import os
 import sys
 import io
 import threading
 import subprocess
-import screed
-import screed_tst_utils as utils
+
 from nose.plugins.attrib import attr
+
+import screed
+from . import screed_tst_utils as utils
+from . import test_fasta
+from . import test_fastq
 from screed.DBConstants import fileExtension
 
 
@@ -72,7 +77,7 @@ def test_stream_gz_fail():
         streamer(utils.get_test_data('test.fastq.gz'))
         assert 0, "This should not work yet"
     except ValueError as err:
-        print str(err)
+        print(str(err))
 
 
 @attr('known_failing')

--- a/screed/utils.py
+++ b/screed/utils.py
@@ -1,0 +1,7 @@
+def to_str(line):
+    try:
+        line = line.decode('utf-8')
+    except AttributeError:
+        pass
+
+    return line

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
+from __future__ import print_function
 try:
     from setuptools import setup
 except ImportError:
-    print '(WARNING: importing distutils, not setuptools!)'
+    print('(WARNING: importing distutils, not setuptools!)')
     from distutils.core import setup
 
 import imp

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py27, py33
 
 [testenv]
-commands = nosetests --with-xcoverage --with-xunit --cover-package=screed --cover-erase
+commands = nosetests --with-xcoverage --with-xunit --cover-package=screed --cover-erase --attr '!known_failing'
 deps =
   nosexcover
   pygr

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,3 @@ envlist = py27, py33, py34
 commands = nosetests --with-xcoverage --with-xunit --cover-package=screed --cover-erase --attr '!known_failing'
 deps =
   nosexcover
-
-[testenv:py27]
-deps =
-  nosexcover
-  pygr

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py27, py33
+envlist = py27, py33, py34
 
 [testenv]
 commands = nosetests --with-xcoverage --with-xunit --cover-package=screed --cover-erase --attr '!known_failing'
 deps =
   nosexcover
-  pygr
 
-[testenv:py33]
+[testenv:py27]
 deps =
   nosexcover
+  pygr


### PR DESCRIPTION
Supersedes #7.

- Properly converting str/bytes.
- Updated tox and Travis to build for py27, py33, py34.
- Absolute and relative imports working as intended.
- Implement missing methods for MutableMapping (`__delitem__`, `__iter__`, `__len__`).