### PR TITLE
screed.open as a context manager

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2015-05-12  Luiz Irber  <screed@luizirber.org>
+
+   * screed/openscreed.py: Implement open as a context manager, keep backward
+   compatibility.
+   * screed/tests/test_open_cm.py: Add same tests as test_open.py, but using
+   a context manager to make sure file is closed after being used.
+
 2015-04-15  Thomas Fenzl  <thomas.fenzl@gmx.net>
 
    * screed/tests/screed_tst_utils.py: removed unnecessary import

--- a/doc/screed.rst
+++ b/doc/screed.rst
@@ -53,8 +53,9 @@ Reading FASTA/FASTQ files
 At the Python prompt, type::
 
    >>> import screed
-   >>> for read in screed.open(filename):
-   ...   print read.name, read.sequence
+   >>> with screed.open(filename) as seqfile:
+   >>>     for read in seqfile:
+   ...         print read.name, read.sequence
 
 Here, 'filename' can be a FASTA or FASTQ file, and can be
 uncompressed, gzipped, or bz2-zipped.

--- a/screed/tests/test_open_cm.py
+++ b/screed/tests/test_open_cm.py
@@ -1,8 +1,5 @@
 # Copyright (c) 2008-2015, Michigan State University
 
-import os.path
-import sys
-import subprocess
 import screed_tst_utils as utils
 import screed
 import screed.openscreed

--- a/screed/tests/test_open_cm.py
+++ b/screed/tests/test_open_cm.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2008-2015, Michigan State University
+
+import os.path
+import sys
+import subprocess
+import screed_tst_utils as utils
+import screed
+import screed.openscreed
+
+
+def test_empty_open():
+    filename = utils.get_test_data('empty.fa')
+    with screed.open(filename) as f:
+        assert len(list(f)) == 0
+
+
+def test_simple_open():
+    filename = utils.get_test_data('test.fa')
+
+    n = -1
+    with screed.open(filename) as f:
+        for n, record in enumerate(f):
+            assert record.name == 'ENSMICT00000012722'
+            break
+
+        assert n == 0, n
+
+
+def test_simple_open_fq():
+    filename = utils.get_test_data('test.fastq')
+
+    n = -1
+    with screed.open(filename) as f:
+        for n, record in enumerate(f):
+            assert record.name == 'HWI-EAS_4_PE-FC20GCB:2:1:492:573/2'
+            break
+
+        assert n == 0
+
+
+def test_gz_open():
+    filename1 = utils.get_test_data('test.fa')
+    filename2 = utils.get_test_data('test.fa.gz')
+    with screed.open(filename1) as f1, screed.open(filename2) as f2:
+        for n, (r1, r2) in enumerate(zip(f1, f2)):
+            assert r1.name == r2.name
+
+        assert n > 0
+
+
+def test_bz2_open():
+    filename1 = utils.get_test_data('test.fa')
+    filename2 = utils.get_test_data('test.fa.bz2')
+    with screed.open(filename1) as f1, screed.open(filename2) as f2:
+        for n, (r1, r2) in enumerate(zip(f1, f2)):
+            assert r1.name == r2.name
+
+        assert n > 0
+
+
+def test_gz_open_fastq():
+    filename1 = utils.get_test_data('test.fastq')
+    filename2 = utils.get_test_data('test.fastq.gz')
+    with screed.open(filename1) as f1, screed.open(filename2) as f2:
+        for n, (r1, r2) in enumerate(zip(f1, f2)):
+            assert r1.name == r2.name
+
+        assert n > 0
+
+
+def test_get_writer_class_fasta():
+    import screed.fasta
+
+    filename = utils.get_test_data('test.fa')
+
+    with screed.open(filename) as f:
+        x = screed.openscreed.get_writer_class(f)
+        assert x is screed.fasta.FASTA_Writer, x
+
+
+def test_unknown_fileformat():
+    try:
+        with screed.open(__file__):
+            pass
+    except ValueError as err:
+        assert "unknown file format" in str(err)


### PR DESCRIPTION
A bit hackish, because I wanted to keep backward compatibility, but it works!

I replicated the tests from test_open.py and replaced every occurence of screed.open with the appropriate context manager block.