### PR TITLE
Add missing close method to screed.open

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2015-05-29  Luiz Irber  <screed@luizirber.org>
+
+   * screed/openscreed.py: Add missing "close" method to context manager.
+
 2015-05-27  Michael R. Crusoe  <mcrusoe@msu.edu>
 
    * MANIFEST.in: ship the recently relocated test data, fixed reference to

--- a/screed/openscreed.py
+++ b/screed/openscreed.py
@@ -98,14 +98,16 @@ class Open(object):
         return self.iter_fn
 
     def __exit__(self, *exc_info):
-        if self.sequencefile is not None:
-            self.sequencefile.close()
+        self.close()
 
     def __iter__(self):
         if self.iter_fn:
             return self.iter_fn
         return iter(())
 
+    def close(self):
+        if self.sequencefile is not None:
+            self.sequencefile.close()
 
 _open = open
 open = Open

--- a/screed/tests/test_open_cm.py
+++ b/screed/tests/test_open_cm.py
@@ -23,6 +23,19 @@ def test_simple_open():
         assert n == 0, n
 
 
+def test_simple_close():
+    filename = utils.get_test_data('test.fa')
+
+    n = -1
+    f = screed.open(filename)
+    for n, record in enumerate(f):
+        assert record.name == 'ENSMICT00000012722'
+        break
+
+    assert n == 0, n
+    f.close()
+
+
 def test_simple_open_fq():
     filename = utils.get_test_data('test.fastq')
 


### PR DESCRIPTION
Some tests were failing on khmer because .close() wasn't implemented. This fixes the problem.