### PR TITLE
Fix operator comparison

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2016-10-04  Luiz Irber  <khmer@luizirber.org>
+
+   * screed/screedRecord.py: Implement comparison using total_ordering
+   decorator from functools.
+   * screed/tests/test_attriberror.py: Fix syntax errors for Python 3 and
+   remove tests for not implemented methods (they are implemented now).
+
 2016-06-10  Titus Brown  <titus@idyll.org>
 
    * screed/dna.py: Fix reverse complement calculation for Python 2.7

--- a/screed/screedRecord.py
+++ b/screed/screedRecord.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from functools import total_ordering
 import types
 from . import DBConstants
 import gzip
@@ -53,6 +54,7 @@ class Record(MutableMapping):
         return repr(self.d)
 
 
+@total_ordering
 class _screed_attr(object):
 
     """
@@ -117,26 +119,11 @@ class _screed_attr(object):
         else:
             return str(given) == self.__str__()
 
-    def __ne__(self, given):
-        """
-        Compares attribute to given object in string form
-        """
-        if isinstance(given, bytes):
-            return self.__repr__() != given
-        else:
-            return self.__repr__() != str(given)
-
     def __lt__(self, given):
-        return NotImplemented
-
-    def __gt__(self, given):
-        return NotImplemented
-
-    def __le__(self, given):
-        return NotImplemented
-
-    def __ge__(self, given):
-        return NotImplemented
+        if isinstance(given, bytes):
+            return self.__str__() < given
+        else:
+            return self.__str__() < str(given)
 
     def __str__(self):
         """

--- a/screed/tests/test_attriberror.py
+++ b/screed/tests/test_attriberror.py
@@ -59,29 +59,5 @@ class test_comparisons():
             res = (record.sequence > self._ns)
             assert res == True, res
 
-    def test_le__(self):
-        for k in self._db:
-            record = self._db.get(k)
-            res = record.sequence.__le__(self._ns)
-            assert res == NotImplemented, res
-
-    def test_ge__(self):
-        for k in self._db:
-            record = self._db.get(k)
-            res = record.sequence.__ge__(self._ns)
-            assert res == NotImplemented, res
-
-    def test_lt__(self):
-        for k in self._db:
-            record = self._db.get(k)
-            res = record.sequence.__lt__(self._ns)
-            assert res == NotImplemented, res
-
-    def test_gt__(self):
-        for k in self._db:
-            record = self._db.get(k)
-            res = record.sequence.__gt__(self._ns)
-            assert res == NotImplemented, res
-
     def teardown(self):
         os.unlink(self._testfile + fileExtension)

--- a/screed/tests/test_attriberror.py
+++ b/screed/tests/test_attriberror.py
@@ -1,7 +1,7 @@
 import screed
 from screed.DBConstants import fileExtension
 import os
-import screed_tst_utils as utils
+from . import screed_tst_utils as utils
 import shutil
 
 
@@ -32,7 +32,7 @@ class test_comparisons():
     def test_neq(self):
         for k in self._db:
             record = self._db.get(k)
-            res = (record.sequence <> self._ns)
+            res = (record.sequence != self._ns)
             assert res == True, res
 
     def test_comp_greateq(self):


### PR DESCRIPTION
- Tests had syntax errors on Python 3
- Uses `functools.total_ordering` to simplify comparisons
- Remove `NotImplemented` comparisons (they are implemented now)