### PR TITLE
Fix test execution when calling as a module

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = screed/tests/*

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
+# If you change anything in addopts,
+# don't forget to update screed/tests/__main__.py too!
 addopts = -m "not known_failing" -v
 testpaths = screed/tests

--- a/screed/tests/__main__.py
+++ b/screed/tests/__main__.py
@@ -8,9 +8,10 @@ if __name__ == '__main__':
         "setup_requires": ['pytest_runner'],
         "tests_require": ['pytest'],
     }
+    rootdir = os.path.dirname(os.path.dirname(__file__))
+    #  TODO: read opts from pytest.ini
+    opts = '-m "not known_failing" -v'
+    sys.argv[1:] = ['pytest', '--addopts=' + opts]
+    os.chdir(rootdir)
     setup(**setup_params)
-
-    import pytest
-    errno = pytest.main(["-m not known_failing", '-v',
-                         os.path.dirname(__file__)])
-    sys.exit(errno)
+    sys.exit()

--- a/screed/tests/__main__.py
+++ b/screed/tests/__main__.py
@@ -1,7 +1,15 @@
 import os
 import sys
 
+
 if __name__ == '__main__':
+    from setuptools import setup
+    setup_params = {
+        "setup_requires": ['pytest_runner'],
+        "tests_require": ['pytest'],
+    }
+    setup(**setup_params)
+
     import pytest
     errno = pytest.main(["-m not known_failing", '-v',
                          os.path.dirname(__file__)])

--- a/screed/tests/__main__.py
+++ b/screed/tests/__main__.py
@@ -1,8 +1,8 @@
+import os
 import sys
 
 if __name__ == '__main__':
     import pytest
-    errno = pytest.main(['-m', '"not known_failing"', '-v'])
-    #errno = pytest.main()
-    print('DEBUG', file=sys.stderr)
+    errno = pytest.main(["-m not known_failing", '-v',
+                         os.path.dirname(__file__)])
     sys.exit(errno)

--- a/screed/tests/__main__.py
+++ b/screed/tests/__main__.py
@@ -2,6 +2,6 @@ import sys
 
 if __name__ == '__main__':
     import pytest
-#    errno = pytest.main(['-m', '"not known_failing"', '-v'])
-    errno = pytest.main()
+    errno = pytest.main(['-m', '"not known_failing"', '-v'])
+    #errno = pytest.main()
     sys.exit(errno)

--- a/screed/tests/__main__.py
+++ b/screed/tests/__main__.py
@@ -4,4 +4,5 @@ if __name__ == '__main__':
     import pytest
     errno = pytest.main(['-m', '"not known_failing"', '-v'])
     #errno = pytest.main()
+    print('DEBUG', file=sys.stderr)
     sys.exit(errno)

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(name='screed',
       author='Alex Nolley, C. Titus Brown',
       author_email='ctb@msu.edu',
       url='http://github.com/dib-lab/screed/',
+      zip_safe=False,
       include_package_data=True,
       packages=['screed', 'screed.tests'],
       package_data={


### PR DESCRIPTION
Fixes dib-lab/khmer#1520

We still have duplicated options (on pytest.ini and screed.tests.__main__), but we can execute
`python -m screed.tests` now (if pytest is installed).

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [ ] `make clean diff-cover` If it introduces new functionality, is it tested?
- [ ] `make format diff_pylint_report doc` Is it well formatted?
- [ ] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
