### PR TITLE
Revert Record changes that break with khmer 2.0

### DIFF
--- a/screed/screedRecord.py
+++ b/screed/screedRecord.py
@@ -29,10 +29,6 @@ class Record(MutableMapping):
 
         d.update(kwargs)
 
-        if 'name' not in d:
-            raise TypeError("'name' must be specified")
-        if 'sequence' not in d:
-            raise TypeError("'sequence' must be specified")
         if 'quality' in d and d['quality'] is None:
             del d['quality']
         self.d = d

--- a/screed/tests/test_open.py
+++ b/screed/tests/test_open.py
@@ -1,4 +1,7 @@
 # Copyright (c) 2008-2015, Michigan State University
+"""
+Test `screed.open`.
+"""
 
 from __future__ import absolute_import
 

--- a/screed/tests/test_open_cm.py
+++ b/screed/tests/test_open_cm.py
@@ -1,4 +1,7 @@
 # Copyright (c) 2008-2015, Michigan State University
+"""
+Test the use of `screed.open` as a ContextManager.
+"""
 
 from . import screed_tst_utils as utils
 import screed

--- a/screed/tests/test_record.py
+++ b/screed/tests/test_record.py
@@ -3,16 +3,6 @@ from screed import Record
 import pytest
 
 
-@pytest.mark.xfail(raises=TypeError)
-def test_create_noname():
-    r = Record(sequence='ATGGAC')
-
-
-@pytest.mark.xfail(raises=TypeError)
-def test_create_noseq():
-    r = Record(name='somename')
-
-
 def test_create_quality_none():
     r = Record(name='foo', sequence='ATGACG', quality=None)
     assert not hasattr(r, 'quality')
@@ -25,10 +15,6 @@ def test_len():
 
 # copied over from khmer tests/test_read_parsers.py
 def test_read_type_basic():
-    # Constructing without mandatory arguments should raise an exception
-    with pytest.raises(TypeError):
-        Record()
-
     name = "895:1:1:1246:14654 1:N:0:NNNNN"
     sequence = "ACGT"
     r = Record(name, sequence)


### PR DESCRIPTION
- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality, is it tested?
- [x] `make format diff_pylint_report doc` Is it well formatted?
- [x] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
