### PR TITLE
Add cleaned_seq attribute to Record

### DIFF
--- a/screed/screedRecord.py
+++ b/screed/screedRecord.py
@@ -26,6 +26,7 @@ class Record(MutableMapping):
             d['name'] = name
         if sequence is not None:
             d['sequence'] = sequence
+            d['cleaned_seq'] = str(sequence).upper().replace("N", "A")
 
         d.update(kwargs)
 
@@ -35,6 +36,8 @@ class Record(MutableMapping):
 
     def __setitem__(self, name, value):
         self.d[name] = value
+        if name == 'sequence':
+            self.d['cleaned_seq'] = value.upper().replace("N", "A")
 
     def __getattr__(self, name):
         try:
@@ -52,6 +55,7 @@ class Record(MutableMapping):
         if isinstance(idx, slice):
             trimmed = dict(self.d)
             trimmed['sequence'] = trimmed['sequence'][idx]
+            trimmed['cleaned_seq'] = trimmed['cleaned_seq'][idx]
             if 'quality' in trimmed:
                 trimmed['quality'] = trimmed['quality'][idx]
             return Record(**trimmed)

--- a/screed/tests/test_record.py
+++ b/screed/tests/test_record.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, unicode_literals, print_function
 from screed import Record
-import pytest
 
 
 def test_create_quality_none():
@@ -32,3 +31,21 @@ def test_read_type_attributes():
     assert r.quality == 'good'
     assert r.name == '1234'
     assert r.annotations == 'ann'
+
+
+def test_set_cleaned_seq():
+    name = "895:1:1:1246:14654 1:N:0:NNNNN"
+    sequence = "ACGTacgtN"
+    r = Record(name, sequence)
+
+    assert r.name == name
+    assert r.sequence == sequence
+    assert r.cleaned_seq == "ACGTACGTA"
+
+
+def test_set_cleaned_seq_slicing():
+    name = "895:1:1:1246:14654 1:N:0:NNNNN"
+    sequence = "ACGTacgtN"
+    r = Record(name, sequence)
+
+    assert r.cleaned_seq[-4:] == "ACGTACGTA"[-4:]


### PR DESCRIPTION
This adds a `cleaned_seq` attribute to `Record` which computes the cleaned version of the sequence when the record is loaded. Trying to keep output of `screed.open()` and `khmer.ReadParser()` as similar as possible.

Related to dib-lab/khmer#1591 which adds the same attribute to records (the `khmer.Read` class) that `khmer.ReadParser` creates or that is seen by `consume_fasta()`.

What tests should be added? Is calling `str(sequence)` smart? I don't know much about how the database part of screed works/assumptions it makes :-/

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [ ] `make clean diff-cover` If it introduces new functionality, is it tested?
- [ ] `make format diff_pylint_report doc` Is it well formatted?
- [ ] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
