### PR TITLE
Passing dict for Record should work

### DIFF
--- a/screed/screedRecord.py
+++ b/screed/screedRecord.py
@@ -1,9 +1,8 @@
 # Copyright (c) 2016, The Regents of the University of California.
 
 from __future__ import absolute_import
-from collections.abc import Mapping
+from collections import Mapping
 from functools import total_ordering
-from . import DBConstants
 from io import BytesIO
 
 try:
@@ -11,6 +10,8 @@ try:
 except ImportError:
     import UserDict
     MutableMapping = UserDict.DictMixin
+
+from . import DBConstants
 
 
 class Record(MutableMapping):
@@ -21,10 +22,10 @@ class Record(MutableMapping):
     def __init__(self, name=None, sequence=None, **kwargs):
         d = dict()
         if name is not None:
-            if isinstance(name, str):
-                d['name'] = name
-            elif isinstance(name, Mapping):
+            if isinstance(name, Mapping):
                 d.update(name)
+            else:
+                d['name'] = name
         if sequence is not None:
             d['sequence'] = sequence
 

--- a/screed/screedRecord.py
+++ b/screed/screedRecord.py
@@ -1,11 +1,9 @@
 # Copyright (c) 2016, The Regents of the University of California.
 
 from __future__ import absolute_import
+from collections.abc import Mapping
 from functools import total_ordering
-import types
 from . import DBConstants
-import gzip
-import bz2
 from io import BytesIO
 
 try:
@@ -23,7 +21,10 @@ class Record(MutableMapping):
     def __init__(self, name=None, sequence=None, **kwargs):
         d = dict()
         if name is not None:
-            d['name'] = name
+            if isinstance(name, str):
+                d['name'] = name
+            elif isinstance(name, Mapping):
+                d.update(name)
         if sequence is not None:
             d['sequence'] = sequence
 

--- a/screed/tests/test_record.py
+++ b/screed/tests/test_record.py
@@ -17,12 +17,15 @@ def test_len():
 def test_read_type_basic():
     name = "895:1:1:1246:14654 1:N:0:NNNNN"
     sequence = "ACGT"
-    r = Record(name, sequence)
 
-    assert r.name == name
-    assert r.sequence == sequence
-    assert not hasattr(r, 'quality'), x
-    assert not hasattr(r, 'annotations'), x
+    r = Record(name, sequence)
+    s = Record(dict(name=name, sequence=sequence))
+
+    for x in (r, s):
+        assert x.name == name
+        assert x.sequence == sequence
+        assert not hasattr(x, 'quality'), x
+        assert not hasattr(x, 'annotations'), x
 
 
 # copied over from khmer tests/test_read_parsers.py


### PR DESCRIPTION
`test_read_type_basic` in [khmer.tests.test_read_parsers][1] passes a [dict to a screed Record][2], so we should support this (I guess?)

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality, is it tested?
- [x] `make format diff_pylint_report doc` Is it well formatted?
- [x] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?

[1]: https://github.com/dib-lab/khmer/blob/effa2b18aa7528cd6852cd342bad3dc47b4c3741/tests/test_read_parsers.py#L48
[2]: https://github.com/dib-lab/khmer/blob/effa2b18aa7528cd6852cd342bad3dc47b4c3741/tests/test_read_parsers.py#L57