### PR TITLE
Use collections.abc for MutableMapping

### DIFF
--- a/screed/openscreed.py
+++ b/screed/openscreed.py
@@ -9,7 +9,7 @@ import sys
 import gzip
 import bz2file
 try:
-    from collections import MutableMapping
+    from collections.abc import MutableMapping
 except ImportError:
     import UserDict
     MutableMapping = UserDict.DictMixin


### PR DESCRIPTION
Addresses deprecation warning:
screed/openscreed.py:12
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import MutableMapping

Fixes #79 