### PR TITLE
[MRG] bump pip/tox cache version numbers

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -36,9 +36,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+          key: ${{ runner.os }}-pip-v2-${{ hashFiles('**/setup.py') }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            ${{ runner.os }}-pip-v2
 
       - name: Install dependencies
         run: |
@@ -49,9 +49,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .tox/
-          key: ${{ runner.os }}-tox-${{ hashFiles('**/setup.py') }}
+          key: ${{ runner.os }}-tox-v2-${{ hashFiles('**/setup.py') }}
           restore-keys: |
-            ${{ runner.os }}-tox-
+            ${{ runner.os }}-tox-v2
 
       - name: Test with tox
         run: tox

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ passenv =
   GITHUB_RUN_ID
   GITHUB_SHA
   GITHUB_REPOSITORY
-whitelist_externals = make
+allowlist_externals = make
 commands =
   make install-dependencies
   pytest --cov -m 'not known_failing'


### PR DESCRIPTION
GitHub actions are currently failing; fixing by -

* bumping cache version numbers
* changing `whitelist_externals` to `allowlist_externals` per https://tox.wiki/en/latest/config.html
