### PR TITLE
Remove pkg_resources usage

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: doc/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .
+  system_packages: true

--- a/screed/__init__.py
+++ b/screed/__init__.py
@@ -36,10 +36,10 @@ from screed.dna import rc
 from screed.screedRecord import Record
 
 
-from pkg_resources import get_distribution, DistributionNotFound
+from importlib.metadata import version, PackageNotFoundError
 try:
-    VERSION = get_distribution(__name__).version
-except DistributionNotFound:  # pragma: no cover
+    VERSION = version(__name__)
+except PackageNotFoundError:  # pragma: no cover
     try:
         from .version import version as VERSION  # noqa
     except ImportError:  # pragma: no cover

--- a/screed/tests/screed_tst_utils.py
+++ b/screed/tests/screed_tst_utils.py
@@ -11,10 +11,15 @@
 import tempfile
 import os
 import shutil
-from importlib import resources
 from io import StringIO
 import sys
 import traceback
+
+from importlib import resources
+
+# Remove when we drop support for 3.8
+if sys.version_info < (3, 9):
+    import importlib_resources as resources
 
 
 def get_test_data(filename):

--- a/screed/tests/screed_tst_utils.py
+++ b/screed/tests/screed_tst_utils.py
@@ -11,20 +11,15 @@
 import tempfile
 import os
 import shutil
-from pkg_resources import Requirement, resource_filename, ResolutionError
+from importlib import resources
 from io import StringIO
 import sys
 import traceback
 
 
 def get_test_data(filename):
-    filepath = None
-    try:
-        filepath = resource_filename(
-            Requirement.parse("screed"), "screed/tests/" + filename)
-    except ResolutionError:
-        pass
-    if not filepath or not os.path.isfile(filepath):
+    filepath = resources.files('screed') / 'screed' / 'tests' / filename
+    if not filepath.exists() or not os.path.isfile(filepath):
         filepath = os.path.join(os.path.dirname(__file__), 'test-data',
                                 filename)
     return filepath

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,5 +50,6 @@ test =
     pytest >= 6.2.2
     pycodestyle
     pytest-cov
+    importlib_resources;python_version<'3.9'
 all =
     %(test)s

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,8 @@
 [tox]
 envlist = py38, py39, py310
+minversion = 3.12
+isolated_build = true
+skip_missing_interpreters = true
 
 [testenv]
 passenv =


### PR DESCRIPTION
`pkg_resources` is part of `setuptools`, so removing it allows not having a runtime dep on `setuptools`. Its usage is also discouraged since `importlib` has the necessary features.
https://setuptools.pypa.io/en/latest/pkg_resources.html

Declare `importlib_resources`  as a dependency for tests in 3.8 (since the `.files()` method was added in 3.9 stdlib)

Update Read the Docs config to avoid the default 3.7 version.

Relevant to https://github.com/sourmash-bio/sourmash/pull/2433 and https://github.com/NixOS/nixpkgs/pull/205878