### PR TITLE
WIP: switch to ubuntu latest for CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         py: ["3.10", 3.9, 3.8]
       fail-fast: false
 


### PR DESCRIPTION
Tests on ubuntu 18.04 are instafailing. Maybe we need to switch to ubuntu-latest?
