### PR TITLE
MRG: rename test methods -> pytest; remove issue template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,0 @@
-- [ ] Is it mergeable?
-- [ ] `make test` Did it pass the tests?
-- [ ] `make clean diff-cover` If it introduces new functionality, is it tested?
-- [ ] `make format diff_pylint_report doc` Is it well formatted?
-- [ ] For substantial changes or changes to the command-line interface, is it
-  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
-  for more details.
-- [ ] Was a spellchecker run on the source code and documentation after
-  changes were made?

--- a/screed/tests/test_attriberror.py
+++ b/screed/tests/test_attriberror.py
@@ -15,7 +15,7 @@ class nostring:
 
 class test_comparisons():
 
-    def setup(self):
+    def setup_method(self):
         self._testfile = utils.get_temp_filename('test.fa')
         shutil.copy(utils.get_test_data('test.fa'), self._testfile)
         screed.read_fasta_sequences(self._testfile)

--- a/screed/tests/test_convert.py
+++ b/screed/tests/test_convert.py
@@ -15,7 +15,7 @@ class Test_fasta_to_fastq(test_fasta.Test_fasta):
     db and then run the fasta suite
     """
 
-    def setup(self):
+    def setup_method(self):
 
         self._fqName = utils.get_temp_filename('fa_to_fq')
         self._faName = utils.get_temp_filename('fq_to_fa')
@@ -29,7 +29,7 @@ class Test_fasta_to_fastq(test_fasta.Test_fasta):
         screed.read_fasta_sequences(self._faName)  # Fasta file -> fasta db
         self.db = screed.ScreedDB(self._faName)
 
-    def teardown(self):
+    def teardown_method(self):
         os.unlink(self._fqName)
         os.unlink(self._fqName + fileExtension)
         os.unlink(self._faName)

--- a/screed/tests/test_dictionary.py
+++ b/screed/tests/test_dictionary.py
@@ -13,14 +13,14 @@ class Test_dict_methods(object):
     queries.
     """
 
-    def setup(self):
+    def setup_method(self):
         self._testfa = utils.get_temp_filename('test.fa')
         shutil.copy(utils.get_test_data('test.fa'), self._testfa)
 
         screed.read_fasta_sequences(self._testfa)
         self.db = screed.ScreedDB(self._testfa)
 
-    def teardown(self):
+    def teardown_method(self):
         os.unlink(self._testfa + fileExtension)
 
     def test_iter_stuff(self):

--- a/screed/tests/test_fasta.py
+++ b/screed/tests/test_fasta.py
@@ -29,14 +29,14 @@ def test_new_record():
 
 class Test_fasta(object):
 
-    def setup(self):
+    def setup_method(self):
         self._testfa = utils.get_temp_filename('test.fa')
         shutil.copy(utils.get_test_data('test.fa'), self._testfa)
 
         screed.read_fasta_sequences(self._testfa)
         self.db = screed.ScreedDB(self._testfa)
 
-    def teardown(self):
+    def teardown_method(self):
         os.unlink(self._testfa + fileExtension)
 
     def test_length(self):
@@ -111,7 +111,7 @@ class Test_fasta(object):
 
 class Test_fasta_whitespace(object):
 
-    def setup(self):
+    def setup_method(self):
         self._testfa = utils.get_temp_filename('test-whitespace.fa')
         shutil.copy(utils.get_test_data('test-whitespace.fa'), self._testfa)
 
@@ -121,7 +121,7 @@ class Test_fasta_whitespace(object):
     def test_for_omitted_record(self):
         assert 'ENSMICT00000012401' in self.db
 
-    def teardown(self):
+    def teardown_method(self):
         os.unlink(self._testfa + fileExtension)
 
 

--- a/screed/tests/test_fasta_recover.py
+++ b/screed/tests/test_fasta_recover.py
@@ -9,7 +9,7 @@ import shutil
 
 class test_fa_recover(test_fasta.Test_fasta):
 
-    def setup(self):
+    def setup_method(self):
         self._fileName = utils.get_temp_filename('fastaRecovery')
 
         self._testfa = utils.get_temp_filename('test.fa')
@@ -20,7 +20,7 @@ class test_fa_recover(test_fasta.Test_fasta):
         screed.read_fasta_sequences(self._fileName)
         self.db = screed.ScreedDB(self._fileName)
 
-    def teardown(self):
+    def teardown_method(self):
         os.unlink(self._fileName)
         os.unlink(self._fileName + fileExtension)
         os.unlink(self._testfa + fileExtension)

--- a/screed/tests/test_fastq.py
+++ b/screed/tests/test_fastq.py
@@ -60,14 +60,14 @@ def test_parse_description_false():
 
 class Test_fastq(object):
 
-    def setup(self):
+    def setup_method(self):
         self._testfq = utils.get_temp_filename('test.fastq')
         shutil.copy(utils.get_test_data('test.fastq'), self._testfq)
 
         screed.read_fastq_sequences(self._testfq)
         self.db = screed.ScreedDB(self._testfq)
 
-    def teardown(self):
+    def teardown_method(self):
         os.unlink(self._testfq + fileExtension)
 
     def test_length(self):

--- a/screed/tests/test_fastq_recover.py
+++ b/screed/tests/test_fastq_recover.py
@@ -9,7 +9,7 @@ import shutil
 
 class test_fq_recover(test_fastq.Test_fastq):
 
-    def setup(self):
+    def setup_method(self):
         self._fileName = utils.get_temp_filename('fastqRecovery')
 
         self._testfq = utils.get_temp_filename('test.fastq')
@@ -20,7 +20,7 @@ class test_fq_recover(test_fastq.Test_fastq):
         screed.read_fastq_sequences(self._fileName)
         self.db = screed.ScreedDB(self._fileName)
 
-    def teardown(self):
+    def teardown_method(self):
         os.unlink(self._fileName)
         os.unlink(self._fileName + fileExtension)
         os.unlink(self._testfq + fileExtension)

--- a/screed/tests/test_hava_methods.py
+++ b/screed/tests/test_hava_methods.py
@@ -12,11 +12,11 @@ shutil.copy(utils.get_test_data('test.hava'), testha)
 
 class test_hava(object):
 
-    def setup(self):
+    def setup_method(self):
         screed.seqparse.read_hava_sequences(testha)
         self._db = screed.ScreedDB(testha)
 
-    def teardown(self):
+    def teardown_method(self):
         b = 7
         # os.unlink(testha + fileExtension)
 

--- a/screed/tests/test_shell.py
+++ b/screed/tests/test_shell.py
@@ -15,7 +15,7 @@ class Test_fa_shell_command(test_fasta.Test_fasta):
     screed database correctly from the shell
     """
 
-    def setup(self):
+    def setup_method(self):
         thisdir = os.path.dirname(__file__)
 
         self._testfa = utils.get_temp_filename('test.fa')
@@ -26,7 +26,7 @@ class Test_fa_shell_command(test_fasta.Test_fasta):
         assert ret == 0, ret
         self.db = screed.ScreedDB(self._testfa)
 
-    def teardown(self):
+    def teardown_method(self):
         os.unlink(self._testfa + fileExtension)
 
 
@@ -37,7 +37,7 @@ class Test_fq_shell_command(test_fastq.Test_fastq):
     screed database correctly from the shell
     """
 
-    def setup(self):
+    def setup_method(self):
         thisdir = os.path.dirname(__file__)
 
         self._testfq = utils.get_temp_filename('test.fastq')
@@ -48,7 +48,7 @@ class Test_fq_shell_command(test_fastq.Test_fastq):
         assert ret == 0, ret
         self.db = screed.ScreedDB(self._testfq)
 
-    def teardown(self):
+    def teardown_method(self):
         os.unlink(self._testfq + fileExtension)
 
 
@@ -59,7 +59,7 @@ class Test_fa_shell_module(test_fasta.Test_fasta):
     screed database correctly from the shell
     """
 
-    def setup(self):
+    def setup_method(self):
         thisdir = os.path.dirname(__file__)
 
         self._testfa = utils.get_temp_filename('test.fa')
@@ -70,7 +70,7 @@ class Test_fa_shell_module(test_fasta.Test_fasta):
         assert ret == 0, ret
         self.db = screed.ScreedDB(self._testfa)
 
-    def teardown(self):
+    def teardown_method(self):
         os.unlink(self._testfa + fileExtension)
 
 
@@ -81,7 +81,7 @@ class Test_fq_shell_module(test_fastq.Test_fastq):
     screed database correctly from the shell
     """
 
-    def setup(self):
+    def setup_method(self):
         thisdir = os.path.dirname(__file__)
 
         self._testfq = utils.get_temp_filename('test.fastq')
@@ -92,7 +92,7 @@ class Test_fq_shell_module(test_fastq.Test_fastq):
         assert ret == 0, ret
         self.db = screed.ScreedDB(self._testfq)
 
-    def teardown(self):
+    def teardown_method(self):
         os.unlink(self._testfq + fileExtension)
 
 
@@ -104,7 +104,7 @@ class Test_convert_shell(test_fasta.Test_fasta):
     db and then run the fasta suite, all from the command line.
     """
 
-    def setup(self):
+    def setup_method(self):
 
         self._fqName = utils.get_temp_filename('fa_to_fq')
         self._faName = utils.get_temp_filename('fq_to_fa')
@@ -133,7 +133,7 @@ class Test_convert_shell(test_fasta.Test_fasta):
 
         self.db = screed.ScreedDB(self._faName)
 
-    def teardown(self):
+    def teardown_method(self):
         os.unlink(self._fqName)
         os.unlink(self._fqName + fileExtension)
         os.unlink(self._faName)


### PR DESCRIPTION
This PR renames `def setup(self)` and `def teardown(self)` (which were nose-testing style naming schemes) to `def setup_method(self)` and `def teardown_method(self)`.

It also removes the obsolete PR template.
