### PR TITLE
MRG: switch screed tests to run monthly

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [latest]
   schedule:
-    - cron: "0 0 * * *" # daily
+    - cron: "0 0 7 * *" # monthly
 
 jobs:
   test:


### PR DESCRIPTION
Since screed is in "I'm very stable and mostly not developed" mode, codecov is rejecting uploads with "Too many uploads to this commit." if we run the tests daily. So I'm going to run them monthly ;)