### PR TITLE
Close sequencefile if an error happens in open_reader

### DIFF
--- a/screed/openscreed.py
+++ b/screed/openscreed.py
@@ -76,6 +76,7 @@ class Open(object):
         try:
             first_char = peek[0]
         except IndexError as err:
+            sequencefile.close()
             return []  # empty file
 
         try:
@@ -89,6 +90,7 @@ class Open(object):
             iter_fn = fastq_iter
 
         if iter_fn is None:
+            sequencefile.close()
             raise ValueError("unknown file format for '%s'" % filename)
 
         self.sequencefile = sequencefile


### PR DESCRIPTION
When running downstream projects with [`PYTHONDEVMODE=1`](https://docs.python.org/3/library/devmode.html) there is a `ResourceWarning` for unclosed files:

```
tests/test_cmd_signature.py::test_sig_kmers_1_dna_empty_seq                                                                                                                                    
  sourmash/.tox/py310/lib/python3.10/site-packages/screed/openscreed.py:35: ResourceWarning: unclosed file <_io.BufferedReader name='/tmp/nix-shell.7nFxtp/so
urmashtest_f12d2h09/query.fa'>                                                                                                                                                                 
    self.iter_fn = self.open_reader(filename, *args, **kwargs)                                                                                                                                 
                                                                                                                                                                                               
  Object allocated at:                                                                                                                                                                         
    File "sourmash/.tox/py310/lib/python3.10/site-packages/screed/openscreed.py", line 35                                                                    
      self.iter_fn = self.open_reader(filename, *args, **kwargs)   
```

Turns out we didn't close the `sequencefile` in the `open_reader` method of `screed.openscreed.Open` for two error cases before raising an exception, and with the fix in this PR the warnings disappear.