### PR TITLE
Docs: system_packages is deprecated in RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,4 +14,3 @@ python:
   install:
     - method: pip
       path: .
-  system_packages: true


### PR DESCRIPTION
More info: https://blog.readthedocs.com/drop-support-system-packages/