### PR TITLE
docs: fix 'retriving' typo in RELEASE-0.5 release notes

### DIFF
--- a/doc/release-notes/RELEASE-0.5.rst
+++ b/doc/release-notes/RELEASE-0.5.rst
@@ -3,7 +3,7 @@ Release v0.5
 ============
 
 We are proud to announce the release of screed v0.5. screed is a database engine
-capable of storing and retriving short-read sequence data. screed is designed
+capable of storing and retrieving short-read sequence data. screed is designed
 to be fast and adaptable to different sequence file formats. This marks the
 first release of screed which we consider stable and complete.
 


### PR DESCRIPTION
Fixes #117.

The RELEASE-0.5 release notes had `storing and retriving` instead of `storing and retrieving`. Because `release-notes/index` is pulled in by `doc/index.rst` and `master_doc='index'`, this line ends up in the sphinx man-page build used during Debian packaging, which is why lintian flags it as `typo-in-manual-page: retriving retrieving`.

This is the only remaining occurrence of the misspelling in the repo; all newer release notes already use `retrieving`.